### PR TITLE
Fix tests and add transformation function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
 var tildify = require('tildify');
@@ -20,20 +19,30 @@ module.exports = function (options) {
 			return cb();
 		}
 
-		var trim = function (buf) {
-			return buf.toString('utf8', 0, options.verbose ? 1000 : 40).trim() + '...\n';
-		}
+		var transform;
+		if (typeof options.transform === 'function') {
+			transform = function(file) {
+				return ' ' + prop(options.transform(file));
+			};
+		} else {
 
-		var fileObj =
-			(file.cwd ? 'cwd:      ' + prop(tildify(file.cwd)) : '') +
-			(file.base ? '\nbase:     ' + prop(tildify(file.base)) : '') +
-			(file.path ? '\npath:     ' + prop(tildify(file.path)) : '') +
-			(file.stat && options.verbose ? '\nstat:     ' + prop(stringifyObject(file.stat)) : '') +
-			(file.contents ? '\ncontents: ' + prop(trim(file.contents)) : '');
+			var trim = function (buf) {
+				return buf.toString('utf8', 0, options.verbose ? 1000 : 40).trim() + '...\n';
+			};
+
+			transform = function(file) {
+				return '\n' +
+					(file.cwd ? 'cwd:      ' + prop(tildify(file.cwd)) : '') +
+					(file.base ? '\nbase:     ' + prop(tildify(file.base)) : '') +
+					(file.path ? '\npath:     ' + prop(tildify(file.path)) : '') +
+					(file.stat && options.verbose ? '\nstat:     ' + prop(stringifyObject(file.stat)) : '') +
+					(file.contents ? '\ncontents: ' + prop(trim(file.contents)) : '');
+			};
+		}
 
 		gutil.log(
 			'gulp-debug: ' + title + chalk.gray('(' + dateTime() + ')') + '\n\n' +
-			header('File\n') + fileObj
+			header('File') + transform(file)
 		);
 
 		this.push(file);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "chalk": "^0.4.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "proxyquire": "^0.6.0",
+    "sinon": "^1.9.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,28 @@ Show more debugging:
 - the file [stat object](http://nodejs.org/api/fs.html#fs_class_fs_stats)
 - shows more of the contents, from 40 bytes to 400 bytes
 
+##### transform
+
+Type: `Function`
+Default: `undefined`
+
+This function gets called with the current processed `file` as only parameter. The return value is used in the log output.
+
+Usage:
+```javascript
+var gulp = require('gulp');
+var debug = require('gulp-debug');
+
+gulp.task('default', function () {
+	return gulp.src('foo.js')
+		.pipe(debug({
+			transform: function(file) {
+				return file.path;
+			}
+		}))
+		.pipe(gulp.dest('dist'));
+});
+```
 
 ## License
 


### PR DESCRIPTION
- This fixes the tests to not tamper with stdout (allows console.log to come in between, allows more fine-grained checks on output, allows more sophisticated mocha reporters). It uses proxyquire now, to replace the `gulp-util` dependencies with a sinon stub
- This adds an option `transform` that can be used to transform the debug output as the user wants to.
