### PR TITLE
Changes to the debug output

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,12 +26,14 @@ module.exports = function (opts) {
 		var full =
 			'\n' +
 			(file.cwd ? 'cwd:   ' + prop(tildify(file.cwd)) : '') +
+			'\nprocess.cwd: ' + prop(process.cwd()) +
+			(file.relative ? '\nrelative:   ' + prop(tildify(file.relative)) : '') +
 			(file.base ? '\nbase:  ' + prop(tildify(file.base)) : '') +
 			(file.path ? '\npath:  ' + prop(tildify(file.path)) : '') +
 			(file.stat && opts.verbose ? '\nstat:' + prop(stringifyObject(file.stat, {indent: '       '}).replace(/[{}]/g, '').trimRight()) : '') +
 			'\n';
 
-		var output = opts.minimal ? prop(path.relative(process.cwd(), file.path)) : full;
+		var output = opts.minimal ? prop(file.relative) : full;
 
 		count++;
 


### PR DESCRIPTION
I made the following changes to the debug output
* Add process.cwd and file.relative to the full output.  
* Switch minimal output to display file.relative rather than the file's path relative to cwd

The code currently does not output `file.relative`; instead, it outputs `path.relative(process.cwd(), file.path)`.  This is misleading, since vinyl doesn't use that algorithm to compute file.relative (it uses `path.relative(file.base, file.path)`).  This change aligns gulp-debug with what vinyl considers to be the relative path.

I also added file.relative to the full output-- I found myself switching back and forth between verbose and non-verbose when debugging because I needed the relative path as well as the other path components.  I added process.cwd() also because it plays a part in vinyl computing file.relative.