### PR TITLE
Adds a logger override to options

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ const prop = chalk.blue;
 module.exports = opts => {
 	opts = Object.assign({
 		title: 'gulp-debug:',
-		minimal: true
+		minimal: true,
+		log: gutil.log
 	}, opts);
 
 	if (process.argv.indexOf('--verbose') !== -1) {
@@ -35,11 +36,11 @@ module.exports = opts => {
 
 		count++;
 
-		gutil.log(opts.title + ' ' + output);
+		opts.log(opts.title + ' ' + output);
 
 		cb(null, file);
 	}, cb => {
-		gutil.log(opts.title + ' ' + chalk.green(count + ' ' + plur('item', count)));
+		opts.log(opts.title + ' ' + chalk.green(count + ' ' + plur('item', count)));
 		cb();
 	});
 };

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,13 @@ By default only relative paths are shown. Turn off minimal mode to also show `cw
 
 The [`stat` property](http://nodejs.org/api/fs.html#fs_class_fs_stats) will be shown when you run gulp in verbose mode: `gulp --verbose`.
 
+##### log
+
+Type: `object`  
+Default: `gutil.log`
+
+By default the output is sent to `gutil.log`.  With this option the logging facility can be overriden to use another logger (such as `onsole.log`).
+
 
 ## License
 


### PR DESCRIPTION
By default this facility only uses gutil.log.  This change adds an
option to override the logger with console.log (or something else).
The use case for this is running gulp with `--silent` because
the build is controlling the logging.