### PR TITLE
Add the ability to only see the count of files in the stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,21 +25,21 @@ module.exports = opts => {
 	let count = 0;
 
 	return through.obj((file, enc, cb) => {
-    if(opts.files){
-      const full =
-        '\n' +
-        (file.cwd ? 'cwd:   ' + prop(tildify(file.cwd)) : '') +
-        (file.base ? '\nbase:  ' + prop(tildify(file.base)) : '') +
-        (file.path ? '\npath:  ' + prop(tildify(file.path)) : '') +
-        (file.stat && opts.verbose ? '\nstat:  ' + prop(stringifyObject(file.stat, {indent: '       '}).replace(/[{}]/g, '').trim()) : '') +
-        '\n';
+		if(opts.files){
+			const full =
+			  '\n' +
+			  (file.cwd ? 'cwd:   ' + prop(tildify(file.cwd)) : '') +
+			  (file.base ? '\nbase:  ' + prop(tildify(file.base)) : '') +
+			  (file.path ? '\npath:  ' + prop(tildify(file.path)) : '') +
+			  (file.stat && opts.verbose ? '\nstat:  ' + prop(stringifyObject(file.stat, {indent: '       '}).replace(/[{}]/g, '').trim()) : '') +
+			  '\n';
 
-      const output = opts.minimal ? prop(path.relative(process.cwd(), file.path)) : full;
+			const output = opts.minimal ? prop(path.relative(process.cwd(), file.path)) : full;
 
-      gutil.log(opts.title + ' ' + output);
-    }
+			gutil.log(opts.title + ' ' + output);
+		}
 
-    count++;
+		count++;
 		cb(null, file);
 	}, cb => {
 		gutil.log(opts.title + ' ' + chalk.green(count + ' ' + plur('item', count)));

--- a/index.js
+++ b/index.js
@@ -12,27 +12,27 @@ const prop = chalk.blue;
 module.exports = opts => {
 	opts = Object.assign({
 		title: 'gulp-debug:',
-    minimal: true,
-    files: true
+		minimal: true,
+		files: true
 	}, opts);
 
 	if (process.argv.indexOf('--verbose') !== -1) {
 		opts.verbose = true;
 		opts.minimal = false;
-    opts.files = true;
+		opts.files = true;
 	}
 
 	let count = 0;
 
 	return through.obj((file, enc, cb) => {
-		if(opts.files){
+		if (opts.files) {
 			const full =
-			  '\n' +
-			  (file.cwd ? 'cwd:   ' + prop(tildify(file.cwd)) : '') +
-			  (file.base ? '\nbase:  ' + prop(tildify(file.base)) : '') +
-			  (file.path ? '\npath:  ' + prop(tildify(file.path)) : '') +
-			  (file.stat && opts.verbose ? '\nstat:  ' + prop(stringifyObject(file.stat, {indent: '       '}).replace(/[{}]/g, '').trim()) : '') +
-			  '\n';
+				'\n' +
+				(file.cwd ? 'cwd:   ' + prop(tildify(file.cwd)) : '') +
+				(file.base ? '\nbase:  ' + prop(tildify(file.base)) : '') +
+				(file.path ? '\npath:  ' + prop(tildify(file.path)) : '') +
+				(file.stat && opts.verbose ? '\nstat:  ' + prop(stringifyObject(file.stat, {indent: '       '}).replace(/[{}]/g, '').trim()) : '') +
+				'\n';
 
 			const output = opts.minimal ? prop(path.relative(process.cwd(), file.path)) : full;
 

--- a/index.js
+++ b/index.js
@@ -13,19 +13,19 @@ module.exports = opts => {
 	opts = Object.assign({
 		title: 'gulp-debug:',
 		minimal: true,
-		files: true
+		showFiles: true
 	}, opts);
 
 	if (process.argv.indexOf('--verbose') !== -1) {
 		opts.verbose = true;
 		opts.minimal = false;
-		opts.files = true;
+		opts.showFiles = true;
 	}
 
 	let count = 0;
 
 	return through.obj((file, enc, cb) => {
-		if (opts.files) {
+		if (opts.showFiles) {
 			const full =
 				'\n' +
 				(file.cwd ? 'cwd:   ' + prop(tildify(file.cwd)) : '') +

--- a/index.js
+++ b/index.js
@@ -12,31 +12,34 @@ const prop = chalk.blue;
 module.exports = opts => {
 	opts = Object.assign({
 		title: 'gulp-debug:',
-		minimal: true
+    minimal: true,
+    files: true
 	}, opts);
 
 	if (process.argv.indexOf('--verbose') !== -1) {
 		opts.verbose = true;
 		opts.minimal = false;
+    opts.files = true;
 	}
 
 	let count = 0;
 
 	return through.obj((file, enc, cb) => {
-		const full =
-			'\n' +
-			(file.cwd ? 'cwd:   ' + prop(tildify(file.cwd)) : '') +
-			(file.base ? '\nbase:  ' + prop(tildify(file.base)) : '') +
-			(file.path ? '\npath:  ' + prop(tildify(file.path)) : '') +
-			(file.stat && opts.verbose ? '\nstat:  ' + prop(stringifyObject(file.stat, {indent: '       '}).replace(/[{}]/g, '').trim()) : '') +
-			'\n';
+    if(opts.files){
+      const full =
+        '\n' +
+        (file.cwd ? 'cwd:   ' + prop(tildify(file.cwd)) : '') +
+        (file.base ? '\nbase:  ' + prop(tildify(file.base)) : '') +
+        (file.path ? '\npath:  ' + prop(tildify(file.path)) : '') +
+        (file.stat && opts.verbose ? '\nstat:  ' + prop(stringifyObject(file.stat, {indent: '       '}).replace(/[{}]/g, '').trim()) : '') +
+        '\n';
 
-		const output = opts.minimal ? prop(path.relative(process.cwd(), file.path)) : full;
+      const output = opts.minimal ? prop(path.relative(process.cwd(), file.path)) : full;
 
-		count++;
+      gutil.log(opts.title + ' ' + output);
+    }
 
-		gutil.log(opts.title + ' ' + output);
-
+    count++;
 		cb(null, file);
 	}, cb => {
 		gutil.log(opts.title + ' ' + chalk.green(count + ' ' + plur('item', count)));

--- a/readme.md
+++ b/readme.md
@@ -34,20 +34,26 @@ gulp.task('default', function () {
 
 ##### title
 
-Type: `string`  
+Type: `string`
 Default: `'gulp-debug:'`
 
 Give it a custom title so it's possible to distinguish the output of multiple instances logging at once.
 
 ##### minimal
 
-Type: `boolean`  
+Type: `boolean`
 Default: `true`
 
 By default only relative paths are shown. Turn off minimal mode to also show `cwd`, `base`, `path`.
 
 The [`stat` property](http://nodejs.org/api/fs.html#fs_class_fs_stats) will be shown when you run gulp in verbose mode: `gulp --verbose`.
 
+##### files
+
+Type: `boolean`
+Default: `true`
+
+By default all files in the stream are printed. Setting this to false will only show the count of files in the stream.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -48,12 +48,12 @@ By default only relative paths are shown. Turn off minimal mode to also show `cw
 
 The [`stat` property](http://nodejs.org/api/fs.html#fs_class_fs_stats) will be shown when you run gulp in verbose mode: `gulp --verbose`.
 
-##### files
+##### showFiles
 
 Type: `boolean`
 Default: `true`
 
-By default all files in the stream are printed. Setting this to false will only show the count of files in the stream.
+Setting this to false will skip printing the file names and only show file counts.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -85,3 +85,17 @@ it('should output plural item count', cb => {
 		});
 	});
 });
+
+it('should not output file names when `showFiles` is false.', cb => {
+	const stream = debug({title: 'unicorn:', showFiles: false});
+
+	stream.on('finish', () => {
+		assert.strictEqual(stripAnsi(gutilStub.log.lastCall.args[0]).split('\n')[0], 'unicorn: 1 item');
+		cb();
+	});
+
+	stream.write(file, () => {
+		assert(gutilStub.log.notCalled);
+		stream.end();
+	});
+});


### PR DESCRIPTION
This PR adds a new 'files' option which can be used to turn off printing of individual files in the stream. This is helpful if you have a large number of files to process. By turning files of, you still get the benefit of knowing how many files are in the stream but it does not impact the speed or legibility of your build. I found this especially helpful in conjuncture with "gulp-changed" to make sure changes were being detected correctly and to see how many files are being processed during incremental builds.