### PR TITLE
Add `showCount` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = options => {
 		options.verbose = true;
 		options.minimal = false;
 		options.showFiles = true;
-    options.showCount = true;
+		options.showCount = true;
 	}
 
 	let count = 0;

--- a/index.js
+++ b/index.js
@@ -13,13 +13,15 @@ module.exports = opts => {
 	opts = Object.assign({
 		title: 'gulp-debug:',
 		minimal: true,
-		showFiles: true
+		showFiles: true,
+		showCount: true
 	}, opts);
 
 	if (process.argv.indexOf('--verbose') !== -1) {
 		opts.verbose = true;
 		opts.minimal = false;
 		opts.showFiles = true;
+		opts.showCount = true;
 	}
 
 	let count = 0;
@@ -42,7 +44,9 @@ module.exports = opts => {
 		count++;
 		cb(null, file);
 	}, cb => {
-		gutil.log(opts.title + ' ' + chalk.green(count + ' ' + plur('item', count)));
+		if (opts.showCount) {
+			gutil.log(opts.title + ' ' + chalk.green(count + ' ' + plur('item', count)));
+		}
 		cb();
 	});
 };

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,12 @@ Default: `true`
 
 Setting this to false will skip printing the file names and only show the file count.
 
+##### showCount
+
+Type: `boolean`<br>
+Default: `true`
+
+Setting this to false will skip printing the file count.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -53,14 +53,15 @@ The [`stat` property](http://nodejs.org/api/fs.html#fs_class_fs_stats) will be s
 Type: `boolean`<br>
 Default: `true`
 
-Setting this to false will skip printing the file names and only show the file count.
+Print filenames.
 
 ##### showCount
 
 Type: `boolean`<br>
 Default: `true`
 
-Setting this to false will skip printing the file count.
+Print the file count.
+
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -97,7 +97,7 @@ test('not output file names when `showFiles` is false.', async t => {
 test('not output count when `showCount` is false.', async t => {
 	const stream = debug({
 		title: 'unicorn:',
-		showCount: false
+		showFiles: false
 	});
 	const finish = pEvent(stream, 'finish');
 
@@ -108,5 +108,5 @@ test('not output count when `showCount` is false.', async t => {
 
 	await finish;
 
-	t.not(stripAnsi(gutilStub.log.lastCall.args[0].split('\n')[0], 'unicorn: 1 item');
+	t.not(stripAnsi(gutilStub.log.lastCall.args[0]).split('\n')[0], 'unicorn: 1 item');
 });

--- a/test.js
+++ b/test.js
@@ -77,7 +77,7 @@ test('output plural item count', async t => {
 	t.is(stripAnsi(gutilStub.log.lastCall.args[0]).split('\n')[0], 'unicorn: 2 items');
 });
 
-test('not output file names when `showFiles` is false.', async t => {
+test('do not output file names when `showFiles` is false', async t => {
 	const stream = debug({
 		title: 'unicorn:',
 		showFiles: false
@@ -94,7 +94,7 @@ test('not output file names when `showFiles` is false.', async t => {
 	t.is(stripAnsi(gutilStub.log.lastCall.args[0]).split('\n')[0], 'unicorn: 1 item');
 });
 
-test('not output count when `showCount` is false.', async t => {
+test('do not output count when `showCount` is false', async t => {
 	const stream = debug({
 		title: 'unicorn:',
 		showCount: false

--- a/test.js
+++ b/test.js
@@ -102,8 +102,7 @@ test('not output count when `showCount` is false.', async t => {
 	const finish = pEvent(stream, 'finish');
 
 	stream.write(file, () => {
-		t.true(gutilStub.log.notCalled);
-		stream.end();
+		stream.end(file);
 	});
 
 	await finish;

--- a/test.js
+++ b/test.js
@@ -93,3 +93,20 @@ test('not output file names when `showFiles` is false.', async t => {
 
 	t.is(stripAnsi(gutilStub.log.lastCall.args[0]).split('\n')[0], 'unicorn: 1 item');
 });
+
+test('not output count when `showCount` is false.', async t => {
+	const stream = debug({
+		title: 'unicorn:',
+		showCount: false
+	});
+	const finish = pEvent(stream, 'finish');
+
+	stream.write(file, () => {
+		t.true(gutilStub.log.notCalled);
+		stream.end();
+	});
+
+	await finish;
+
+	t.not(stripAnsi(gutilStub.log.lastCall.args[0].split('\n')[0], 'unicorn: 1 item');
+});

--- a/test.js
+++ b/test.js
@@ -97,7 +97,7 @@ test('not output file names when `showFiles` is false.', async t => {
 test('not output count when `showCount` is false.', async t => {
 	const stream = debug({
 		title: 'unicorn:',
-		showFiles: false
+		showCount: false
 	});
 	const finish = pEvent(stream, 'finish');
 


### PR DESCRIPTION
With the "showFiles" option, only seems right to have a "showCount" option.
Synchronous tasks put the total count out of order when listing files as well.

Great plugin, Thanks!!