### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('path');
-const gutil = require('gulp-util');
+const fancyLog = require('fancy-log');
 const through = require('through2');
 const tildify = require('tildify');
 const stringifyObject = require('stringify-object');
@@ -36,13 +36,16 @@ module.exports = opts => {
 
 			const output = opts.minimal ? prop(path.relative(process.cwd(), file.path)) : full;
 
-			gutil.log(opts.title + ' ' + output);
+			module.exports._log(opts.title + ' ' + output);
 		}
 
 		count++;
 		cb(null, file);
 	}, cb => {
-		gutil.log(opts.title + ' ' + chalk.green(count + ' ' + plur('item', count)));
+		module.exports._log(opts.title + ' ' + chalk.green(count + ' ' + plur('item', count)));
 		cb();
 	});
 };
+
+// Internal: Log function used by gulp-debug exposed for testing.
+module.exports._log = fancyLog;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
-    "gulp-util": "^3.0.0",
+    "fancy-log": "^1.3.2",
     "plur": "^2.0.0",
     "stringify-object": "^3.0.0",
     "through2": "^2.0.0",
@@ -42,9 +42,9 @@
     "ava": "*",
     "gulp": "^3.8.10",
     "p-event": "^1.0.0",
-    "proxyquire": "^1.0.1",
     "sinon": "^2.1.0",
     "strip-ansi": "^3.0.0",
+    "vinyl": "^2.1.0",
     "xo": "*"
   },
   "ava": {


### PR DESCRIPTION
Closes sindresorhus/gulp-debug#40

This one was a bit tricky because the tests spied on `gutil.log`. I tried to provide an alternative approach by exposing the log function on the main export but I am not familiar enough with `sinon`. Feel free to comment / make changes.
