### PR TITLE
Add `logger` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const prop = chalk.blue;
 
 module.exports = options => {
 	options = Object.assign({
+		logger: fancyLog,
 		title: 'gulp-debug:',
 		minimal: true,
 		showFiles: true
@@ -36,16 +37,13 @@ module.exports = options => {
 
 			const output = options.minimal ? prop(path.relative(process.cwd(), file.path)) : full;
 
-			module.exports._log(options.title + ' ' + output);
+			options.logger(options.title + ' ' + output);
 		}
 
 		count++;
 		cb(null, file);
 	}, cb => {
-		module.exports._log(options.title + ' ' + chalk.green(count + ' ' + plur('item', count)));
+		options.logger(options.title + ' ' + chalk.green(count + ' ' + plur('item', count)));
 		cb();
 	});
 };
-
-// Internal: Log function used by gulp-debug exposed for testing
-module.exports._log = fancyLog;

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,13 @@ Default: `true`
 
 Setting this to false will skip printing the file names and only show the file count.
 
+##### logger(<message>)
+
+Type: `Function(<string>)`<br>
+Default: [`fancy-log`](https://github.com/js-cli/fancy-log)
+
+Provide your own logging utility in place of [fancy-log](https://github.com/js-cli/fancy-log). The message is passed as a string in the first positional argument. Note that [ANSI colors](https://github.com/chalk/chalk) may be used in the message.
+
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -57,12 +57,12 @@ Default: `true`
 
 Setting this to false will skip printing the file names and only show the file count.
 
-##### logger(<message>)
+##### logger(message)
 
-Type: `Function(<string>)`<br>
+Type: `Function`<br>
 Default: [`fancy-log`](https://github.com/js-cli/fancy-log)
 
-Provide your own logging utility in place of [fancy-log](https://github.com/js-cli/fancy-log). The message is passed as a string in the first positional argument. Note that [ANSI colors](https://github.com/chalk/chalk) may be used in the message.
+Provide your own logging utility in place of [fancy-log](https://github.com/js-cli/fancy-log). The message is passed as a string in the first argument. Note that [ANSI colors](https://github.com/chalk/chalk) may be used in the message.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -109,9 +109,7 @@ test('not output file names when `showFiles` is false.', async t => {
 test('using the default logger', async t => {
 	const stream = debug();
 	const finish = pEvent(stream, 'finish');
-
 	stream.end(file);
-
 	await finish;
 
 	t.pass();

--- a/test.js
+++ b/test.js
@@ -1,18 +1,31 @@
 import fs from 'fs';
 import path from 'path';
 import test from 'ava';
-import sinon from 'sinon';
 import Vinyl from 'vinyl';
 import stripAnsi from 'strip-ansi';
 import pEvent from 'p-event';
 import debug from '.';
 
-const sandbox = sinon.sandbox.create();
+const logInspect = {
+	messages: [],
+	logger(msg) {
+		logInspect.messages.push(stripAnsi(msg));
+	},
+	get notCalled() {
+		return this.messages.length === 0;
+	},
+	get firstMessage() {
+		return this.messages[0];
+	},
+	get lastMessage() {
+		return this.messages[this.messages.length - 1];
+	}
+};
 
 let file;
 
 test.beforeEach(() => {
-	sandbox.spy(debug, '_log');
+	logInspect.messages = [];
 
 	file = new Vinyl({
 		cwd: __dirname,
@@ -23,39 +36,47 @@ test.beforeEach(() => {
 	});
 });
 
-test.afterEach(() => {
-	sandbox.restore();
-});
-
 test('output debug info', async t => {
-	const stream = debug({title: 'unicorn:'});
+	const stream = debug({
+		logger: logInspect.logger,
+		title: 'unicorn:'
+	});
 	const finish = pEvent(stream, 'finish');
 	stream.end(file);
 	await finish;
 
-	t.is(stripAnsi(debug._log.firstCall.args[0]).split('\n')[0], 'unicorn: foo.js');
+	t.is(logInspect.firstMessage, 'unicorn: foo.js');
 });
 
 test('output singular item count', async t => {
-	const stream = debug({title: 'unicorn:'});
+	const stream = debug({
+		logger: logInspect.logger,
+		title: 'unicorn:'
+	});
 	const finish = pEvent(stream, 'finish');
 	stream.end(file);
 	await finish;
 
-	t.is(stripAnsi(debug._log.lastCall.args[0]).split('\n')[0], 'unicorn: 1 item');
+	t.is(logInspect.lastMessage, 'unicorn: 1 item');
 });
 
 test('output zero item count', async t => {
-	const stream = debug({title: 'unicorn:'});
+	const stream = debug({
+		logger: logInspect.logger,
+		title: 'unicorn:'
+	});
 	const finish = pEvent(stream, 'finish');
 	stream.end();
 	await finish;
 
-	t.is(stripAnsi(debug._log.lastCall.args[0]).split('\n')[0], 'unicorn: 0 items');
+	t.is(logInspect.lastMessage, 'unicorn: 0 items');
 });
 
 test('output plural item count', async t => {
-	const stream = debug({title: 'unicorn:'});
+	const stream = debug({
+		logger: logInspect.logger,
+		title: 'unicorn:'
+	});
 	const finish = pEvent(stream, 'finish');
 
 	stream.write(file, () => {
@@ -64,22 +85,23 @@ test('output plural item count', async t => {
 
 	await finish;
 
-	t.is(stripAnsi(debug._log.lastCall.args[0]).split('\n')[0], 'unicorn: 2 items');
+	t.is(logInspect.lastMessage, 'unicorn: 2 items');
 });
 
 test('not output file names when `showFiles` is false.', async t => {
 	const stream = debug({
+		logger: logInspect.logger,
 		title: 'unicorn:',
 		showFiles: false
 	});
 	const finish = pEvent(stream, 'finish');
 
 	stream.write(file, () => {
-		t.true(debug._log.notCalled);
+		t.true(logInspect.notCalled);
 		stream.end();
 	});
 
 	await finish;
 
-	t.is(stripAnsi(debug._log.lastCall.args[0]).split('\n')[0], 'unicorn: 1 item');
+	t.is(logInspect.lastMessage, 'unicorn: 1 item');
 });

--- a/test.js
+++ b/test.js
@@ -105,3 +105,14 @@ test('not output file names when `showFiles` is false.', async t => {
 
 	t.is(logInspect.lastMessage, 'unicorn: 1 item');
 });
+
+test('using the default logger', async t => {
+	const stream = debug();
+	const finish = pEvent(stream, 'finish');
+
+	stream.end(file);
+
+	await finish;
+
+	t.pass();
+});


### PR DESCRIPTION
Adding a new logger option to allow users to specify a different logging utility in place of [fancy-log](//github.com/js-cli/fancy-log).

Implements #42.